### PR TITLE
update :

### DIFF
--- a/src/main/java/com/application/letschat/config/WebSocketConfig.java
+++ b/src/main/java/com/application/letschat/config/WebSocketConfig.java
@@ -22,13 +22,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic");
+        config.enableSimpleBroker("/topic", "/queue");
         config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/websocket").setAllowedOrigins("*").addInterceptors(new JwtHandshakeInterceptor(jwtUtil));
+        registry.addEndpoint("/websocket")
+                .setAllowedOrigins("*");
+//                .addInterceptors(new JwtHandshakeInterceptor(jwtUtil));
     }
 
 }

--- a/src/main/java/com/application/letschat/config/jwt/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/application/letschat/config/jwt/JwtHandshakeInterceptor.java
@@ -1,5 +1,6 @@
 package com.application.letschat.config.jwt;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -40,11 +41,31 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 //        return false;
 //    }
 
+//    @Override
+//    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+//                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
+//        if (request instanceof ServletServerHttpRequest) {
+//            ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+//            HttpHeaders headers = servletRequest.getHeaders();
+//            System.out.println("Headers: " + headers); // Should now include Authorization
+//            String authHeader = headers.getFirst("Authorization");
+//            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+//                String token = authHeader.substring(7);
+//                if (jwtUtil.validateToken(token)) {
+//                    Integer userId = jwtUtil.getUserIdFromToken(token);
+//                    attributes.put("userId", userId);
+//                    return true;
+//                }
+//            }
+//        }
+//        response.setStatusCode(HttpStatus.UNAUTHORIZED);
+//        return false;
+//    }
+
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                    WebSocketHandler wsHandler, Map<String, Object> attributes) {
         String token = null;
-
         if (request instanceof ServletServerHttpRequest) {
             ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
             String query = servletRequest.getServletRequest().getQueryString();
@@ -53,7 +74,6 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
                 token = query.split("token=")[1].split("&")[0]; // Extract token from query string
             }
         }
-
         if (token != null && jwtUtil.validateToken(token)) {
             Integer userId = jwtUtil.getUserIdFromToken(token);
             attributes.put("userId", userId);

--- a/src/main/java/com/application/letschat/controller/chatRoom/ChatRoomController.java
+++ b/src/main/java/com/application/letschat/controller/chatRoom/ChatRoomController.java
@@ -3,8 +3,13 @@ package com.application.letschat.controller.chatRoom;
 import com.application.letschat.config.jwt.JwtUtil;
 import com.application.letschat.dto.chatRoom.ChatRoomCreateDTO;
 import com.application.letschat.dto.chatRoom.ChatRoomDTO;
+import com.application.letschat.model.chatRoom.ChatRoom;
+import com.application.letschat.model.message.Message;
+import com.application.letschat.repository.chatRoom.ChatRoomRepository;
+import com.application.letschat.repository.message.MessageRepository;
 import com.application.letschat.service.chatRoom.ChatRoomService;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,13 +23,18 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/chatroom")
+@RequiredArgsConstructor
 public class ChatRoomController {
 
-    @Autowired
-    private ChatRoomService chatRoomService;
+    private final ChatRoomService chatRoomService;
 
-    @Autowired
-    private JwtUtil jwtUtil;
+    private final JwtUtil jwtUtil;
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    private final MessageRepository messageRepository;
+
+
 
     @PostMapping("/create")
     public ResponseEntity<Map<String, Long>> createChatRoom(@RequestBody ChatRoomCreateDTO chatRoomCreateDTO) {
@@ -43,15 +53,47 @@ public class ChatRoomController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/check-access")
-    public ResponseEntity<Boolean> checkAccess(@RequestParam("chatRoomId") Long chatRoomId,
-                                               @RequestHeader("Authorization") String authorizationHeader) {
-        String token = authorizationHeader.replace("Bearer ", "");
-        System.out.println(chatRoomId);
-        System.out.println(token);
+//    @PostMapping("/check-access")
+//    public ResponseEntity<Boolean> checkAccess(@RequestParam("chatRoomId") Long chatRoomId,
+//                                               @RequestHeader("Authorization") String authorizationHeader) {
+//        String token = authorizationHeader.replace("Bearer ", "");
+//        System.out.println(chatRoomId);
+//        System.out.println(token);
+//
+//        boolean isValid = chatRoomService.checkAccess(token, chatRoomId);
+//        System.out.println(isValid);
+//        return ResponseEntity.ok(isValid);
+//    }
 
-        boolean isValid = chatRoomService.checkAccess(token, chatRoomId);
-        System.out.println(isValid);
-        return ResponseEntity.ok(isValid);
+    @GetMapping("/chat-history")
+    public ResponseEntity<Map<String, Object>> getMessages(@RequestParam("chatRoomId") Long chatRoomId,
+                                                           @RequestHeader("Authorization") String authorizationHeader) {
+
+        String token = authorizationHeader.replace("Bearer ", "");
+        boolean isValid = chatRoomService.checkAccess(token, chatRoomId);  //유저가 채팅방에 존재하는지 확인.
+
+        if (!isValid) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of());
+        } else {
+            ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                    .orElseThrow(() -> new RuntimeException("Chat room not found"));
+            List<Message> messages = messageRepository.findByChatRoom(chatRoom);
+            List<Map<String, Object>> messageDtos = messages.stream()
+                    .map(m -> {
+                        Map<String, Object> map = new HashMap<>();
+                        map.put("chatRoomId", m.getChatRoom().getChatRoomId());
+                        map.put("senderId", m.getUser().getUserId());
+                        map.put("senderName", m.getUser().getName());
+                        map.put("content", m.getContent());
+                        map.put("enrolledAt", m.getEnrolledAt());
+                        return map;
+                    })
+                    .toList();
+            Map<String, Object> response = Map.of(
+                    "chatRoomName", chatRoom.getChatRoomName(),
+                    "messages", messageDtos
+            );
+            return ResponseEntity.ok(response);
+        }
     }
 }

--- a/src/main/java/com/application/letschat/controller/message/MessageController.java
+++ b/src/main/java/com/application/letschat/controller/message/MessageController.java
@@ -1,5 +1,6 @@
 package com.application.letschat.controller.message;
 
+import com.application.letschat.config.jwt.JwtUtil;
 import com.application.letschat.dto.message.MessageDTO;
 import com.application.letschat.model.chatRoom.ChatRoom;
 import com.application.letschat.model.message.Message;
@@ -7,13 +8,18 @@ import com.application.letschat.model.user.User;
 import com.application.letschat.repository.chatRoom.ChatRoomRepository;
 import com.application.letschat.repository.message.MessageRepository;
 import com.application.letschat.repository.user.UserRepository;
+import com.application.letschat.service.chatRoom.ChatRoomService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.HashMap;
@@ -33,6 +39,10 @@ public class MessageController {
 
     private final ChatRoomRepository chatRoomRepository;
 
+    private final ChatRoomService chatRoomService;
+
+    private final JwtUtil jwtUtil;
+
     @MessageMapping("all-chat")
     public void sendAllChat(@Payload MessageDTO messageDTO) {
 
@@ -41,7 +51,6 @@ public class MessageController {
 
 
     }
-
 
     @MessageMapping("/private-message")
     public void sendPrivateMessage(@Payload MessageDTO messageDTO){
@@ -65,27 +74,26 @@ public class MessageController {
 
     }
 
-    @GetMapping("/api/chat/messages")
-    public ResponseEntity<Map<String, Object>> getMessages(@RequestParam("chatRoomId") Long chatRoomId) {
-        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new RuntimeException("Chat room not found"));
-        List<Message> messages = messageRepository.findByChatRoom(chatRoom);
-        List<Map<String, Object>> messageDtos = messages.stream()
-                .map(m -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("chatRoomId", m.getChatRoom().getChatRoomId());
-                    map.put("senderId", m.getUser().getUserId());
-                    map.put("senderName", m.getUser().getName());
-                    map.put("content", m.getContent());
-                    map.put("enrolledAt", m.getEnrolledAt());
-                    return map;
-                })
-                .toList();
-        Map<String, Object> response = Map.of(
-                "chatRoomName", chatRoom.getChatRoomName(),
-                "messages", messageDtos
-        );
-        return ResponseEntity.ok(response);
+    @MessageMapping("/authenticate")
+    @SendToUser("/queue/auth")
+    public String authenticate(@Header("Authorization") String authHeader,
+                             @Header("simpSessionId") String sessionId) {
+
+        String result = "";
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+
+            if (jwtUtil.validateToken(token)) {
+                Integer userId = jwtUtil.getUserIdFromToken(token);
+                System.out.println("Authenticated user " + userId + " for session " + sessionId);
+                result = "Authentication successful";
+            } else {
+                result = "Invalid token";
+            }
+        } else {
+            result = "Missing token";
+        }
+        return result;
     }
 
 }

--- a/src/main/resources/static/chat-room.html
+++ b/src/main/resources/static/chat-room.html
@@ -22,101 +22,116 @@
         return;
       }
 
-      //validate if the user belongs to the chat or not.
-      fetch(`/api/chatroom/check-access?chatRoomId=${chatRoomId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-      })
-              .then(response => {
-
-                if (!response.ok) {
-                  throw new Error('Access denied or error: ' + response.status);
-                }
-                return response.json();
-              })
-              .then(data => {
-                if (data == false) {
-                  throw new Error('User does not belong to this chat room');
-                }
-              })
-              .catch(error => {
-                console.error('Error checking access:', error);
-                document.getElementById('chatMessages').innerHTML = '<p>Access denied</p>';
-                setTimeout(() => window.location.href = '/chat-list.html', 2000);
-              });
-
-      // Load chat history
-      fetch(`/api/chat/messages?chatRoomId=${chatRoomId}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}` //토큰 전송
-        }
-      })
-              .then(response => {
-                if (!response.ok) throw new Error('Failed to load chat history');
-                return response.json();
-              })
-              .then(data => {
-                document.getElementById('chatRecipient').textContent = data.chatRoomName;
-
-                const messagesDiv = document.getElementById('chatMessages');
-                data.messages.forEach(msg => {
-                  const messageDiv = document.createElement('div');
-                  messageDiv.classList.add('message', msg.senderId == userId ? 'sent' : 'received');
-
-                  // Only show sender name for received messages
-                  if (msg.senderId != userId) {
-                    const senderNameDiv = document.createElement('div');
-                    senderNameDiv.classList.add('sender-name');
-                    senderNameDiv.textContent = msg.senderName;
-                    messageDiv.appendChild(senderNameDiv);
-                  }
-
-                  // Message content
-                  const messageContentDiv = document.createElement('div');
-                  messageContentDiv.classList.add('message-content');
-                  messageContentDiv.textContent = msg.content;
-
-                  //time
-                  const messageTimeDiv = document.createElement('div');
-                  messageTimeDiv.classList.add('message-time');
-                  const date = new Date(msg.enrolledAt);
-                  const hours = String(date.getHours()).padStart(2, '0');
-                  const minutes = String(date.getMinutes()).padStart(2, '0');
-                  const year = date.getFullYear();
-                  const month = String(date.getMonth() + 1).padStart(2, '0'); // Months are 0-based
-                  const day = String(date.getDate()).padStart(2, '0');
-                  messageTimeDiv.textContent = `${year}-${month}-${day} / ${hours}:${minutes} `;
-
-                  //appending them all to messageDiv
-                  messageDiv.appendChild(messageContentDiv);
-                  messageDiv.appendChild(messageTimeDiv);
-                  messagesDiv.appendChild(messageDiv);
-
-
-
-                });
-
-                scrollToBottom();
-              })
-              .catch(error => console.error('Error loading history:', error));
-
 //WebSocket Connection
       const stompClient = new StompJs.Client({
         //brokerURL: `wss://syoo.shop/websocket?token=${token}`
         brokerURL: `ws://localhost:8080/websocket?token=${token}`
       });
-
       stompClient.activate();
 
+      //WebSocket subscription management.
       stompClient.onConnect = (frame) => {
         console.log('Connected: ' + frame);
-        console.log(`Subscribing to: /topic/private-chat/${chatRoomId}`);
 
+        console.log("checking if the user is authenticated or not.")
+        stompClient.subscribe('/user/queue/auth', (message) => {
+          console.log("Auth response: " + message.body);
+          if (message.body === "Authentication successful") {
+            console.log("User is authenticated!");
+
+            // 채팅히스토리 call. (여기서 유저가 채팅방에 있는지도 검사함).
+            console.log("retrieving chat history")
+            chatHistory();
+
+          } else {
+            console.log("Authentication failed: " + message.body);
+            // Handle failure (e.g., disconnect)
+            stompClient.deactivate();
+          }
+        });
+        stompClient.publish({
+          destination: "/app/authenticate",
+          headers: { "Authorization": `Bearer ${token}` }
+        });
+
+      };
+
+
+
+      // Load chat history
+      function chatHistory() {
+        fetch(`/api/chatroom/chat-history?chatRoomId=${chatRoomId}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}` //토큰 전송
+          }
+        })
+                .then(response => {
+                  //채팅방에 해당 유저가 없음.
+                  if (!response.ok) throw new Error('Failed to load chat history');
+                  return response.json();
+                })
+                .then(data => {
+
+                  //채팅방에 구독 시작
+                  console.log(`Subscribing to: /topic/private-chat/${chatRoomId}`);
+                  subscribeToChatRoom();
+
+                  document.getElementById('chatRecipient').textContent = data.chatRoomName;
+
+                  const messagesDiv = document.getElementById('chatMessages');
+                  data.messages.forEach(msg => {
+                    const messageDiv = document.createElement('div');
+                    messageDiv.classList.add('message', msg.senderId == userId ? 'sent' : 'received');
+
+                    // Only show sender name for received messages
+                    if (msg.senderId != userId) {
+                      const senderNameDiv = document.createElement('div');
+                      senderNameDiv.classList.add('sender-name');
+                      senderNameDiv.textContent = msg.senderName;
+                      messageDiv.appendChild(senderNameDiv);
+                    }
+
+                    // Message content
+                    const messageContentDiv = document.createElement('div');
+                    messageContentDiv.classList.add('message-content');
+                    messageContentDiv.textContent = msg.content;
+
+                    //time
+                    const messageTimeDiv = document.createElement('div');
+                    messageTimeDiv.classList.add('message-time');
+                    const date = new Date(msg.enrolledAt);
+                    const hours = String(date.getHours()).padStart(2, '0');
+                    const minutes = String(date.getMinutes()).padStart(2, '0');
+                    const year = date.getFullYear();
+                    const month = String(date.getMonth() + 1).padStart(2, '0'); // Months are 0-based
+                    const day = String(date.getDate()).padStart(2, '0');
+                    messageTimeDiv.textContent = `${year}-${month}-${day} / ${hours}:${minutes} `;
+
+                    //appending them all to messageDiv
+                    messageDiv.appendChild(messageContentDiv);
+                    messageDiv.appendChild(messageTimeDiv);
+                    messagesDiv.appendChild(messageDiv);
+
+                  });
+
+                  scrollToBottom();
+                })
+                .catch(error => {
+                  console.error('Error checking access:', error);
+                  console.error('Error loading history:', error);
+                  console.log('user does not have access to this chat')
+                  document.getElementById('chatMessages').innerHTML = '<p>Access denied</p>';
+                  setTimeout(() => window.location.href = '/chat-list.html', 2000);
+                });
+      }
+
+
+
+
+      //해당 채팅방 구독 함수로 뺴놓기
+      function subscribeToChatRoom() {
         // Subscribe using template literals (backticks)
         stompClient.subscribe(`/topic/private-chat/${chatRoomId}`, (message) => {
           const msgData = JSON.parse(message.body);
@@ -161,7 +176,9 @@
           messagesDiv.appendChild(messageDiv);
           messagesDiv.scrollTop = messagesDiv.scrollHeight;
         });
-      };
+      }
+
+
 
       const messageInput = document.getElementById('messageInput');
       if (messageInput) {
@@ -179,7 +196,7 @@
         messagesDiv.scrollTop = messagesDiv.scrollHeight;
       }
 
-      // Chat Window ()
+      document.getElementById('sendButton').addEventListener('click', sendMessage);
       function sendMessage() {
         const input = document.getElementById('messageInput');
         const messageText = input.value.trim();
@@ -200,7 +217,6 @@
 
     });
 
-
   </script>
 
 
@@ -214,7 +230,7 @@
   <div class="chat-messages" id="chatMessages"></div>
   <div class="chat-input">
     <input type="text" id="messageInput" placeholder="Type a message...">
-    <button onclick="sendMessage()">Send</button>
+    <button id="sendButton">Send</button>
   </div>
 </div>
 </body>


### PR DESCRIPTION
웹소켓 보안 방식 변경

기존엔 token을 websocket 연결을 처음할 때 url로 보냈음. header에 들어가질 않아서. 그러면 token이 너무 쉽게 노출이 됨

변경사항

-웹소켓 연결은 그냥 가능 (interceptor 제거)
-웹소켓 커넥션 후 바로 구독을 user/queue/authenticate 으로 구독하고 바로 첫 메세지로 헤더에 token 넣어서 보냄 
-토큰유효화 확인 후 구독하고있는 주소로 보내서 auth, no auth여부 확인
-auth인 경우 챗 히스토리 불러오는 로직 실행. 그 로직 안에서 이 유저가 채팅방에 초대가 된 사람이 맞는지 확인. (그 전에는 두개가 다른 http요청으로 나눠져있었음. 하나로 합침. 리소스 줄이기) 
-맞으면 채팅방 구독 아니면 access denied.